### PR TITLE
Bug fix for SBM estimator with some size-one block and loops=False

### DIFF
--- a/docs/reference/release.rst
+++ b/docs/reference/release.rst
@@ -3,6 +3,19 @@
 Release Log
 ===========
 
+graspologic 3.3.0
+-----------------
+- Added features and bugfixes to ``heatmap``
+  `#750 <https://github.com/microsoft/graspologic/pull/750>`
+- Fixed type specification bugs related to Numpy 1.25 release
+  `#1047 <https://github.com/microsoft/graspologic/pull/1047>`
+- Added option for more efficient graph matching matrix operations
+  `#1046 <https://github.com/microsoft/graspologic/pull/1046>`
+- Added an axis argument to ``screeplot``
+  `#1048 <https://github.com/microsoft/graspologic/pull/1048>`
+- Fixed compatibility issues related to matplotlib 3.8 release 
+  `#1049 <https://github.com/microsoft/graspologic/pull/1049>`
+
 graspologic 3.2.0
 -----------------
 - Added Python 3.11 support

--- a/docs/tutorials/plotting/heatmaps.ipynb
+++ b/docs/tutorials/plotting/heatmaps.ipynb
@@ -16,19 +16,21 @@
    "outputs": [],
    "source": [
     "import graspologic\n",
-    "\n",
-    "import numpy as np\n",
-    "%matplotlib inline"
+    "import numpy as np"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Plotting graphs using heatmap\n",
-    "\n",
-    "### Simulate graphs using weighted stochastic block models\n",
-    "The 2-block model is defined as below:\n",
+    "## Plotting Simple Graphs using heatmap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A 2-block Stochastic Block Model is defined as below:\n",
     "\n",
     "\\begin{align*}\n",
     "P = \\begin{bmatrix}0.8 & 0.2 \\\\\n",
@@ -36,7 +38,7 @@
     "\\end{bmatrix}\n",
     "\\end{align*}\n",
     "\n",
-    "We generate two weight SBMs where the weights are distributed from a Poisson(3) and Normal(5, 1)."
+    "In simple cases, the model is unweighted. Below, we plot an unweighted SBM."
    ]
   },
   {
@@ -46,25 +48,28 @@
    "outputs": [],
    "source": [
     "from graspologic.simulations import sbm\n",
+    "from graspologic.plot import heatmap\n",
     "\n",
     "n_communities = [50, 50]\n",
     "p = [[0.8, 0.2], \n",
     "     [0.2, 0.8]]\n",
     "\n",
-    "wt = np.random.poisson\n",
-    "wtargs = dict(lam=3)\n",
-    "A_poisson= sbm(n_communities, p, wt=wt, wtargs=wtargs)\n",
-    "\n",
-    "wt = np.random.normal\n",
-    "wtargs = dict(loc=5, scale=1)\n",
-    "A_normal = sbm(n_communities, p, wt=wt, wtargs=wtargs)"
+    "A, labels = sbm(n_communities, p, return_labels=True)\n",
+    "heatmap(A, title=\"Basic Heatmap function\");"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Plot the simulated weighted SBMs"
+    "## Plotting with Hierarchy Labels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we have labels, we can use them to show communities on a Heatmap."
    ]
   },
   {
@@ -73,10 +78,54 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from graspologic.plot import heatmap\n",
+    "heatmap(A, inner_hier_labels=labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can plot outer hierarchy labels in addition to inner hierarchy labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outer_labels = [\"Outer Labels\"] * 100\n",
+    "heatmap(A, inner_hier_labels=labels,\n",
+    "        outer_hier_labels=outer_labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Weighted SBMs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also use heatmap when our graph is weighted. Here, we generate two weighted SBMs where the weights are distributed from a Poisson(3) and Normal(5, 1)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Draw weights from a Poisson(3) distribution\n",
+    "wt = np.random.poisson\n",
+    "wtargs = dict(lam=3)\n",
+    "A_poisson= sbm(n_communities, p, wt=wt, wtargs=wtargs)\n",
     "\n",
-    "title = 'Weighted Stochastic Block Model with Poisson(3)'\n",
-    "\n",
+    "# Plot\n",
+    "title = 'Weighted Stochastic Block Model with \\n weights drawn from a Poisson(3) distribution'\n",
     "fig= heatmap(A_poisson, title=title)"
    ]
   },
@@ -86,18 +135,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "title = 'Weighted Stochastic Block Model with Normal(5, 1)'\n",
+    "# Draw weights from a Normal(5, 1) distribution\n",
+    "wt = np.random.normal\n",
+    "wtargs = dict(loc=5, scale=1)\n",
+    "A_normal = sbm(n_communities, p, wt=wt, wtargs=wtargs)\n",
     "\n",
-    "fig= heatmap(A_normal, title=title)"
+    "# Plot\n",
+    "title = 'Weighted Stochastic Block Model with \\n weights drawn from a Normal(5, 1) distribution'\n",
+    "fig = heatmap(A_normal, title=title)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### You can also change color maps\n",
+    "### Colormaps\n",
     "\n",
-    "See [here](https://matplotlib.org/tutorials/colors/colormaps.html) for a list of colormaps"
+    "You can change colormaps. See [here](https://matplotlib.org/tutorials/colors/colormaps.html) for a list of colormaps."
    ]
   },
   {
@@ -107,8 +161,7 @@
    "outputs": [],
    "source": [
     "title = 'Weighted Stochastic Block Model with Poisson(3)'\n",
-    "\n",
-    "fig= heatmap(A_poisson, title=title, transform=None, cmap=\"binary\", center=None)"
+    "fig = heatmap(A_poisson, title=title, transform=None, cmap=\"binary\", center=None)"
    ]
   },
   {
@@ -203,7 +256,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/graspologic/embed/svd.py
+++ b/graspologic/embed/svd.py
@@ -7,11 +7,11 @@ import numpy as np
 import scipy
 import scipy.sparse as sp
 import sklearn
+from scipy.sparse import csr_array
 from scipy.stats import norm
 from typing_extensions import Literal
 
 from graspologic.types import List, Tuple
-from graspologic.utils import is_almost_symmetric
 
 SvdAlgorithmType = Literal["full", "truncated", "randomized", "eigsh"]
 
@@ -107,7 +107,7 @@ def select_dimension(
         pp.918-930.
     """
     # Handle input data
-    if not isinstance(X, np.ndarray) and not sp.isspmatrix_csr(X):
+    if not isinstance(X, (np.ndarray, csr_array)):
         msg = "X must be a numpy array or scipy.sparse.csr_array, not {}.".format(
             type(X)
         )

--- a/graspologic/layouts/render.py
+++ b/graspologic/layouts/render.py
@@ -127,9 +127,9 @@ def _draw_graph(
     for source, target in graph.edges():
         edge_color_list.append(node_colors[source])
 
-    ax.set_xbound(x_domain)
+    ax.set_xbound(*x_domain)
     ax.set_xlim(x_domain)
-    ax.set_ybound(y_domain)
+    ax.set_ybound(*y_domain)
     ax.set_ylim(y_domain)
 
     nx.draw_networkx_edges(

--- a/graspologic/match/wrappers.py
+++ b/graspologic/match/wrappers.py
@@ -69,6 +69,7 @@ def graph_match(
     transport_regularizer: Scalar = 100,
     transport_tol: Scalar = 5e-2,
     transport_max_iter: Int = 1000,
+    fast: bool = True,
 ) -> MatchResult:
     """
     Attempts to solve the Graph Matching Problem or the Quadratic Assignment Problem
@@ -192,6 +193,12 @@ def graph_match(
         Setting this value higher may provide more precise solutions at the cost of
         longer computation time.
 
+    fast: bool, default=True
+        Whether to use numerical shortcuts to speed up the computation. Typically will
+        be faster for most applications, although requires storing intermediate
+        computations in memory which may be undesirable for very large inputs or when
+        memory is a bottleneck.
+
     Returns
     -------
     res: MatchResult
@@ -281,7 +288,6 @@ def graph_match(
         partial_match=partial_match,
         init=init,
         init_perturbation=init_perturbation,
-        verbose=solver_verbose,
         shuffle_input=shuffle_input,
         padding=padding,
         maximize=maximize,
@@ -291,6 +297,7 @@ def graph_match(
         transport_regularizer=transport_regularizer,
         transport_tol=transport_tol,
         transport_max_iter=transport_max_iter,
+        fast=fast,
     )
 
     def run_single_graph_matching(seed: RngType) -> MatchResult:

--- a/graspologic/models/sbm_estimators.py
+++ b/graspologic/models/sbm_estimators.py
@@ -516,6 +516,8 @@ def _calculate_block_p(
         if return_counts:
             p = np.count_nonzero(block)
         else:
+            if block.size == 0:
+                continue
             p = _calculate_p(block)
         block_p[from_block, to_block] = p
     return block_p

--- a/graspologic/plot/plot.py
+++ b/graspologic/plot/plot.py
@@ -1,7 +1,8 @@
 ﻿# Copyright (c) Microsoft Corporation and contributors.
 # Licensed under the MIT License.
 
-from typing import Any, Collection, Optional, Union
+import warnings
+from typing import Any, Collection, Literal, Optional, Union
 
 import matplotlib as mpl
 import matplotlib.axes
@@ -286,18 +287,22 @@ def heatmap(
         if len(xticklabels) != X.shape[1]:
             msg = "xticklabels must have same length {}.".format(X.shape[1])
             raise ValueError(msg)
-    elif not isinstance(xticklabels, bool):
-        msg = "xticklabels must be a bool or a list, not {}".format(type(xticklabels))
+
+    elif not isinstance(xticklabels, (bool, int)):
+        msg = "xticklabels must be a bool, int, or a list, not {}".format(
+            type(xticklabels)
+        )
         raise TypeError(msg)
 
     if isinstance(yticklabels, list):
         if len(yticklabels) != X.shape[0]:
             msg = "yticklabels must have same length {}.".format(X.shape[0])
             raise ValueError(msg)
-    elif not isinstance(yticklabels, bool):
-        msg = "yticklabels must be a bool or a list, not {}".format(type(yticklabels))
+    elif not isinstance(yticklabels, (bool, int)):
+        msg = "yticklabels must be a bool, int, or a list, not {}".format(
+            type(yticklabels)
+        )
         raise TypeError(msg)
-
     # Handle cmap
     if not isinstance(cmap, (str, list, Colormap)):
         msg = "cmap must be a string, list of colors, or matplotlib.colors.Colormap,"
@@ -314,6 +319,11 @@ def heatmap(
     if not isinstance(cbar, bool):
         msg = "cbar must be a bool, not {}.".format(type(center))
         raise TypeError(msg)
+
+    # Warning on labels
+    if (inner_hier_labels is None) and (outer_hier_labels is not None):
+        msg = "outer_hier_labels requires inner_hier_labels to be used."
+        warnings.warn(msg)
 
     arr = import_graph(X)
 
@@ -432,7 +442,7 @@ def gridplot(
         Set of colors for mapping the ``hue`` variable. If a dict, keys should
         be values in the ``hue`` variable.
         For acceptable string arguments, see the palette options at
-        :doc:`Choosing Colormaps in Matplotlib <tutorials/colors/colormaps>`
+        :doc:`Choosing Colormaps in Matplotlib <users/explain/colors/colormaps>`
     alpha : float [0, 1], default : 0.7
         Alpha value of plotted gridplot points
     sizes : length 2 tuple, default: (10, 200)
@@ -597,7 +607,7 @@ def pairplot(
         Set of colors for mapping the ``hue`` variable. If a dict, keys should
         be values in the ``hue`` variable.
         For acceptable string arguments, see the palette options at
-        :doc:`Choosing Colormaps in Matplotlib <tutorials/colors/colormaps>`.
+        :doc:`Choosing Colormaps in Matplotlib <users/explain/colors/colormaps>`.
     alpha : float, optional, default: 0.7
         Opacity value of plotter markers between 0 and 1
     size : float or int, optional, default: 50
@@ -753,10 +763,10 @@ def _plot_ellipse_and_data(
         angle = np.arctan(u[1] / u[0])
         angle = 180.0 * angle / np.pi
         ell = mpl.patches.Ellipse(
-            [mean[j], mean[k]],
+            (mean[j], mean[k]),
             v[0],
             v[1],
-            180.0 + angle,
+            angle=180.0 + angle,
             color=cluster_palette[i],
         )
         ell.set_clip_box(ax.bbox)
@@ -974,7 +984,7 @@ def pairplot_with_gmm(
             handles, labels = axes[1].get_legend_handles_labels()
         fig.legend(
             handles,
-            labels,
+            labels,  # type: ignore
             loc="center right",
             title=legend_name,
         )
@@ -1059,7 +1069,7 @@ def degreeplot(
         Set of colors for mapping the ``hue`` variable. If a dict, keys should
         be values in the ``hue`` variable.
         For acceptable string arguments, see the palette options at
-        :doc:`Choosing Colormaps in Matplotlib <tutorials/colors/colormaps>`.
+        :doc:`Choosing Colormaps in Matplotlib <users/explain/colors/colormaps>`.
     figsize : tuple of length 2, default (10, 5)
         Size of the figure (width, height)
 
@@ -1128,7 +1138,7 @@ def edgeplot(
         Set of colors for mapping the ``hue`` variable. If a dict, keys should
         be values in the ``hue`` variable.
         For acceptable string arguments, see the palette options at
-        :doc:`Choosing Colormaps in Matplotlib <tutorials/colors/colormaps>`.
+        :doc:`Choosing Colormaps in Matplotlib <users/explain/colors/colormaps>`.
     figsize : tuple of length 2, default (10, 5)
         Size of the figure (width, height)
 
@@ -1411,6 +1421,7 @@ def screeplot(
     context: str = "talk",
     font_scale: float = 1,
     figsize: Tuple[int, int] = (10, 5),
+    ax: Optional[matplotlib.axes.Axes] = None,
     cumulative: bool = True,
     show_first: Optional[int] = None,
     show_elbow: Optional[Union[bool, int]] = False,
@@ -1470,8 +1481,11 @@ def screeplot(
         y = np.cumsum(D[:show_first])
     else:
         y = D[:show_first]
+
+    if ax is None:
+        ax = plt.gca()
+
     _ = plt.figure(figsize=figsize)
-    ax = plt.gca()
     xlabel = "Component"
     ylabel = "Variance explained"
     with sns.plotting_context(context=context, font_scale=font_scale):
@@ -1583,6 +1597,8 @@ def _plot_groups(
     fontsize: int = 30,
 ) -> matplotlib.pyplot.Axes:
     inner_labels_arr = np.array(inner_labels)
+    if outer_labels is not None:
+        outer_labels_arr = np.array(outer_labels)
     plot_outer = True
     if outer_labels is None:
         outer_labels_arr = np.ones_like(inner_labels)
@@ -1604,17 +1620,17 @@ def _plot_groups(
     axline_kws = dict(linestyle="dashed", lw=0.9, alpha=0.3, zorder=3, color="grey")
     # draw lines
     for x in inner_freq_cumsum[1:-1]:
-        ax.vlines(x, 0, n_verts + 1, **axline_kws)
-        ax.hlines(x, 0, n_verts + 1, **axline_kws)
+        ax.vlines(x, 0, n_verts + 1, **axline_kws)  # type: ignore
+        ax.hlines(x, 0, n_verts + 1, **axline_kws)  # type: ignore
 
     # add specific lines for the borders of the plot
     pad = 0.001
     low = pad
     high = 1 - pad
-    ax.plot((low, low), (low, high), transform=ax.transAxes, **axline_kws)
-    ax.plot((low, high), (low, low), transform=ax.transAxes, **axline_kws)
-    ax.plot((high, high), (low, high), transform=ax.transAxes, **axline_kws)
-    ax.plot((low, high), (high, high), transform=ax.transAxes, **axline_kws)
+    ax.plot((low, low), (low, high), transform=ax.transAxes, **axline_kws)  # type: ignore
+    ax.plot((low, high), (low, low), transform=ax.transAxes, **axline_kws)  # type: ignore
+    ax.plot((high, high), (low, high), transform=ax.transAxes, **axline_kws)  # type: ignore
+    ax.plot((low, high), (high, high), transform=ax.transAxes, **axline_kws)  # type: ignore
 
     # generic curve that we will use for everything
     lx = np.linspace(-np.pi / 2.0 + 0.05, np.pi / 2.0 - 0.05, 500)
@@ -1632,7 +1648,7 @@ def _plot_groups(
 
     # top inner curves
     ax_x = divider.new_vertical(size="5%", pad=0.0, pack_start=False)
-    ax.figure.add_axes(ax_x)
+    ax.figure.add_axes(ax_x)  # type: ignore
     _plot_brackets(
         ax_x,
         np.tile(inner_unique, len(outer_unique)),
@@ -1646,7 +1662,7 @@ def _plot_groups(
     )
     # side inner curves
     ax_y = divider.new_horizontal(size="5%", pad=0.0, pack_start=True)
-    ax.figure.add_axes(ax_y)
+    ax.figure.add_axes(ax_y)  # type: ignore
     _plot_brackets(
         ax_y,
         np.tile(inner_unique, len(outer_unique)),
@@ -1663,7 +1679,7 @@ def _plot_groups(
         # top outer curves
         pad_scalar = 0.35 / 30 * fontsize
         ax_x2 = divider.new_vertical(size="5%", pad=pad_scalar, pack_start=False)
-        ax.figure.add_axes(ax_x2)
+        ax.figure.add_axes(ax_x2)  # type: ignore
         _plot_brackets(
             ax_x2,
             outer_unique,
@@ -1677,7 +1693,7 @@ def _plot_groups(
         )
         # side outer curves
         ax_y2 = divider.new_horizontal(size="5%", pad=pad_scalar, pack_start=True)
-        ax.figure.add_axes(ax_y2)
+        ax.figure.add_axes(ax_y2)  # type: ignore
         _plot_brackets(
             ax_y2,
             outer_unique,
@@ -1699,7 +1715,7 @@ def _plot_brackets(
     tick_width: np.ndarray,
     curve: np.ndarray,
     level: str,
-    axis: str,
+    axis: Literal["both", "x", "y"],
     max_size: int,
     fontsize: int,
 ) -> None:

--- a/graspologic/plot/plot_matrix.py
+++ b/graspologic/plot/plot_matrix.py
@@ -156,11 +156,11 @@ def _remove_shared_ax(ax):
     """
     Remove ax from its sharex and sharey
     """
-    # Remove ax from the Grouper object
-    shax = ax.get_shared_x_axes()
-    shay = ax.get_shared_y_axes()
-    shax.remove(ax)
-    shay.remove(ax)
+    # # Remove ax from the Grouper object
+    # shax = ax.get_shared_x_axes()
+    # shay = ax.get_shared_y_axes()
+    # shax.remove(ax)
+    # shay.remove(ax)
 
     # Set a new ticker with the respective new locator and formatter
     for axis in [ax.xaxis, ax.yaxis]:

--- a/graspologic/utils/utils.py
+++ b/graspologic/utils/utils.py
@@ -12,7 +12,7 @@ import pandas as pd
 import scipy.sparse
 from beartype import beartype
 from scipy.optimize import linear_sum_assignment
-from scipy.sparse import csgraph, csr_array, diags, isspmatrix_csr
+from scipy.sparse import csgraph, csr_array, diags
 from scipy.sparse.csgraph import connected_components
 from sklearn.metrics import confusion_matrix
 from sklearn.utils import check_array, check_consistent_length, column_or_1d
@@ -43,7 +43,7 @@ def average_matrices(
     """
     if isinstance(matrices[0], np.ndarray):
         return np.mean(matrices, axis=0)  # type: ignore
-    elif isspmatrix_csr(matrices[0]):
+    elif isinstance(matrices[0], csr_array):
         return np.sum(matrices) / len(matrices)
 
     raise TypeError(f"Unexpected type {matrices}")
@@ -275,11 +275,11 @@ def is_almost_symmetric(
     Raises
     ------
     TypeError
-        If the provided graph is not a numpy.ndarray or scipy.sparse.spmatrix
+        If the provided graph is not a numpy.ndarray or scipy.sparse.csr_array
     """
     if (x.ndim != 2) or (x.shape[0] != x.shape[1]):
         return False
-    if isinstance(x, (np.ndarray, scipy.sparse.spmatrix)):
+    if isinstance(x, (np.ndarray, csr_array)):
         return abs(x - x.T).max() <= atol
     else:
         raise TypeError("input a correct matrix type.")
@@ -836,7 +836,7 @@ def augment_diagonal(
     degrees = (in_degrees + out_degrees) / 2
     diag = weight * degrees / divisor
 
-    graph += diags(diag) if isspmatrix_csr(graph) else np.diag(diag)
+    graph += diags(diag) if isinstance(graph, csr_array) else np.diag(diag)
 
     return graph
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = graspologic
-version = 3.2.0
+version = 3.3.0
 
 description = A set of python modules for graph statistics
 long_description = file: README.md

--- a/tests/partition/test_leiden.py
+++ b/tests/partition/test_leiden.py
@@ -193,8 +193,10 @@ class TestLeiden(unittest.TestCase):
         node_ids = partitions.keys()
         for node_id in node_ids:
             self.assertTrue(
-                isinstance(node_id, (np.int32, np.intc)),
-                f"{node_id} has {type(node_id)} should be an np.int32/np.intc",
+                isinstance(
+                    node_id, np.integer
+                ),  # this is the preferred numpy typecheck
+                f"{node_id} has {type(node_id)} should be an int",
             )
 
     def test_hierarchical(self):

--- a/tests/test_spectral_embed.py
+++ b/tests/test_spectral_embed.py
@@ -164,6 +164,7 @@ class TestAdjacencySpectralEmbed(unittest.TestCase):
     def test_directed_correct_latent_positions(self):
         # setup
         ase = AdjacencySpectralEmbed(n_components=3)
+        np.random.seed(8888)
         P = np.array([[0.9, 0.1, 0.1], [0.3, 0.6, 0.1], [0.1, 0.5, 0.6]])
         M, labels = sbm([200, 200, 200], P, directed=True, return_labels=True)
 


### PR DESCRIPTION
#### Reference Issues/PRs
See Issue #1055

#### What does this implement/fix? Briefly explain your changes.
## Expected Behavior
Any size-1 block should just have zero probability.

## Actual Behavior
In `sbm_estimators.py`, `_calculate_block_p` calls `_calculate_p`, which divides zero when `block.size = 0`.
This can happen when some block has size one and `loops=False` is used.

Adding 
```
if block.size == 0:
    continue
```
before Line 519 of `graspologic/graspologic/models/sbm_estimators.py` should do the trick.
