### PR TITLE
Update sbm_estimators.py

### DIFF
--- a/graspologic/models/sbm_estimators.py
+++ b/graspologic/models/sbm_estimators.py
@@ -516,6 +516,8 @@ def _calculate_block_p(
         if return_counts:
             p = np.count_nonzero(block)
         else:
+            if block.size == 0:
+                continue
             p = _calculate_p(block)
         block_p[from_block, to_block] = p
     return block_p


### PR DESCRIPTION
#### Reference Issues/PRs
See Issue #1055

#### What does this implement/fix? Briefly explain your changes.
## Expected Behavior
Any size-1 block should just have zero probability.

## Actual Behavior
In `sbm_estimators.py`, `_calculate_block_p` calls `_calculate_p`, which divides zero when `block.size = 0`.
This can happen when some block has size one and `loops=False` is used.

Adding 
```
if block.size == 0:
    continue
```
before Line 519 of `graspologic/graspologic/models/sbm_estimators.py` should do the trick.
