### PR TITLE
Move single-length matrix strategy dimensions to env-vars

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,22 +12,21 @@ on:
       - '.all-contributorsrc'
       - 'CONTRIBUTORS.md'
   workflow_call:
+
 env:
   PYTHON_VERSION: '3.10'
   POETRY_VERSION: '1.8.3'
+
 jobs:
   build-reference-documentation:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
     steps:
       - run: sudo apt-get install -y pandoc
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Poetry
         uses: abatilo/actions-poetry@v3.0.0
         with:
@@ -58,7 +57,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: $PYTHON_VERSION
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Poetry
         uses: abatilo/actions-poetry@v3.0.0
         with:
@@ -74,7 +73,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: $PYTHON_VERSION
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Poetry
         uses: abatilo/actions-poetry@v3.0.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,15 @@ on:
       - '.all-contributorsrc'
       - 'CONTRIBUTORS.md'
   workflow_call:
+env:
+  PYTHON_VERSION: '3.10'
+  POETRY_VERSION: '1.8.3'
 jobs:
   build-reference-documentation:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10"]
-        poetry-version: ["1.8.2"]
     steps:
       - run: sudo apt-get install -y pandoc
       - uses: actions/checkout@v2
@@ -26,10 +28,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Poetry ${{ matrix.poetry-version }}
+      - name: Install Poetry
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: ${{ matrix.poetry-version }}
+          poetry-version: $POETRY_VERSION
       - name: Install dependencies
         run: poetry install
       - name: "Run Reference Documentation Generation"
@@ -51,40 +53,32 @@ jobs:
             docs/_build/html
   code-format-check:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-        poetry-version: ["1.8.2"]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Poetry ${{ matrix.poetry-version }}
+          python-version: $PYTHON_VERSION
+      - name: Install Poetry
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: ${{ matrix.poetry-version }}
+          poetry-version: $POETRY_VERSION
       - name: Install dependencies
         run: poetry install
       - name: Run Format Check
         run: poetry run poe static_checks
   test-coverage:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-        poetry-version: ["1.8.2"]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Poetry ${{ matrix.poetry-version }}
+          python-version: $PYTHON_VERSION
+      - name: Install Poetry
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: ${{ matrix.poetry-version }}
+          poetry-version: $POETRY_VERSION
       - name: Install dependencies
         run: poetry install
       - name: Run Test Coverage
@@ -95,7 +89,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python_version: ["3.9", "3.10", "3.11", "3.12"]
-        poetry-version: ["1.8.2"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -103,10 +96,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python_version}}
-      - name: Install Poetry ${{ matrix.poetry-version }}
+      - name: Install Poetry
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: ${{ matrix.poetry-version }}
+          poetry-version: $POETRY_VERSION
       - name: Install dependencies
         run: poetry install
       - name: Run Unit Tests and Doctests Python ${{matrix.python_version}} ${{matrix.os}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ on:
     branches:
       - 'main'
       - 'dev'
+env:
+  PYTHON_VERSION: '3.10'
+  POETRY_VERSION: '1.8.3'
 jobs:
   build:
     uses: ./.github/workflows/build.yml
@@ -22,10 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.ref=='refs/heads/main' || github.ref=='refs/heads/dev'
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-        poetry-version: ["1.8.2"]
     permissions:
       id-token: write
     steps:
@@ -33,14 +32,14 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Poetry ${{ matrix.poetry-version }}
+          python-version: $PYTHON_VERSION
+      - name: Install Poetry
         uses: abatilo/actions-poetry@v3.0.0
         with:
-          poetry-version: ${{ matrix.poetry-version }}
+          poetry-version: $POETRY_VERSION
       - name: Add poetry-dynamic-versioning plugin
         run: poetry self add "poetry-dynamic-versioning[plugin]"
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: $PYTHON_VERSION
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Poetry
         uses: abatilo/actions-poetry@v3.0.0
         with:


### PR DESCRIPTION
This CI update moves matrix-strategy dimensions with a single value into env variables. This simplifies the output task names, and will let us update Poetry versions without interfering with branch protection strategies.